### PR TITLE
RFC5545 only allows datetime resolution to seconds, not milliseconds

### DIFF
--- a/lib/calex/encoder.ex
+++ b/lib/calex/encoder.ex
@@ -30,7 +30,7 @@ defmodule Calex.Encoder do
   defp encode_value({k, {%DateTime{time_zone: "Etc/UTC"} = datetime, props}}) do
     encoded_datetime =
       datetime
-      |> DateTime.truncate(:millisecond)
+      |> DateTime.truncate(:second)
       |> Timex.format!("{ISO:Basic:Z}")
 
     # TZID property should not be set when datetime is in UTC
@@ -43,7 +43,7 @@ defmodule Calex.Encoder do
   defp encode_value({k, {%DateTime{time_zone: time_zone} = datetime, props}}) do
     encoded_datetime =
       datetime
-      |> DateTime.truncate(:millisecond)
+      |> DateTime.truncate(:second)
       |> Timex.format!("{YYYY}{0M}{0D}T{0h24}{m}{s}")
 
     props = Keyword.put(props, :tzid, time_zone)

--- a/test/calex/encoding_test.exs
+++ b/test/calex/encoding_test.exs
@@ -69,6 +69,29 @@ defmodule Calex.EncodingTest do
              """)
   end
 
+  test "encodes UTC dates to second resolution" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              dtstamp: {~U[2021-06-01 00:00:00.123Z], []}
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             DTSTAMP:20210601T000000Z
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
   test "encodes non-UTC dates" do
     data = [
       vcalendar: [
@@ -76,6 +99,29 @@ defmodule Calex.EncodingTest do
           vevent: [
             [
               dtstamp: {DateTime.from_naive!(~N[2021-06-01 00:00:00], "America/Chicago"), []}
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             DTSTAMP;TZID=America/Chicago:20210601T000000
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
+  test "encodes non-UTC dates to second resolution" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              dtstamp: {DateTime.from_naive!(~N[2021-06-01 00:00:00.123], "America/Chicago"), []}
             ]
           ]
         ]


### PR DESCRIPTION
resolves #2 

I tried running tests locally but ran into some issues install dependencies.  I had to locally upgrade `ssl_verify_fun` with `mix deps.update ssl_verify_fun` and then I was able to successfully run tests.