### PR TITLE
Naive datetime

### DIFF
--- a/lib/calex/encoder.ex
+++ b/lib/calex/encoder.ex
@@ -50,6 +50,16 @@ defmodule Calex.Encoder do
     encode_value({k, {encoded_datetime, props}})
   end
 
+  # encode naive datetime values
+  defp encode_value({k, {%NaiveDateTime{} = datetime, props}}) do
+    encoded_datetime =
+      datetime
+      |> NaiveDateTime.truncate(:second)
+      |> Timex.format!("{YYYY}{0M}{0D}T{0h24}{m}{s}")
+
+    encode_value({k, {encoded_datetime, props}})
+  end
+
   # encode value with properties
   defp encode_value({k, {v, [{_k, _v} | _] = props}}) do
     encoded_props =

--- a/test/calex/decoding_test.exs
+++ b/test/calex/decoding_test.exs
@@ -53,6 +53,26 @@ defmodule Calex.DecodingTest do
            ]
   end
 
+  test "decodes naive/floating datetimes" do
+    data =
+      crlf("""
+      BEGIN:DAYLIGHT
+      DTSTART:20241103T010000
+      END:DAYLIGHT
+      """)
+
+    assert Calex.decode!(data) == [
+             daylight: [
+               [
+                 dtstart:
+                   {~N[2024-11-03 01:00:00], []}
+               ]
+             ]
+           ]
+
+    assert Calex.encode!(Calex.decode!(data)) == data
+  end
+
   test "decodes dates" do
     data =
       crlf("""
@@ -244,29 +264,6 @@ defmodule Calex.DecodingTest do
                  vevent: [
                    [
                      duration: {Timex.Duration.from_hours(1), []}
-                   ]
-                 ]
-               ]
-             ]
-           ]
-  end
-
-  test "decodes malformed timestamps without zone info as UTC" do
-    data =
-      crlf("""
-      BEGIN:VCALENDAR
-      BEGIN:VEVENT
-      DTSTAMP:20210601T000000
-      END:VEVENT
-      END:VCALENDAR
-      """)
-
-    assert Calex.decode!(data) == [
-             vcalendar: [
-               [
-                 vevent: [
-                   [
-                     dtstamp: {~U[2021-06-01 00:00:00Z], []}
                    ]
                  ]
                ]

--- a/test/calex/encoding_test.exs
+++ b/test/calex/encoding_test.exs
@@ -138,6 +138,29 @@ defmodule Calex.EncodingTest do
              """)
   end
 
+  test "encodes naive datetimes" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              dtstart: {~N[2021-06-01 00:00:00.123], []}
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             DTSTART:20210601T000000
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
   test "encodes dates" do
     data = [
       vcalendar: [


### PR DESCRIPTION
 * resolves #1

Previously the code assumed a floating datetime was "malformed" and assumed it to be UTC.  However, floating datetime values are completely valid and should remain as naive datetime values (they're also necessary to properly define VTIMEZONE blocks).

You may want to look at the PR changes ignoring whitespace, I introduced an `if` and had to indent a chunk of code.