### PR TITLE
Proper escaping on parameter and property values

### DIFF
--- a/lib/calex/decoder.ex
+++ b/lib/calex/decoder.ex
@@ -27,7 +27,7 @@ defmodule Calex.Decoder do
         {[], acc <> rest}
 
       line, prevline ->
-        {(prevline && [String.replace(prevline, "\\n", "\n")]) || [], line}
+        {(prevline && [prevline]) || [], line}
     end)
     |> elem(0)
   end
@@ -117,8 +117,19 @@ defmodule Calex.Decoder do
         decode_duration(val)
 
       true ->
-        val
+        unescape_prop_value(val)
     end
+  end
+
+  defp unescape_prop_value(val) do
+    val
+    |> String.replace(~r/\\(\\|;|,|N|n)/, fn
+      "\\\\" -> "\\"
+      "\\;" -> ";"
+      "\\," -> ","
+      "\\N" -> "\n"
+      "\\n" -> "\n"
+    end)
   end
 
   defp decode_local_datetime(val, time_zone) do

--- a/lib/calex/decoder.ex
+++ b/lib/calex/decoder.ex
@@ -51,40 +51,54 @@ defmodule Calex.Decoder do
 
   # decode key,params and value for each prop
   defp decode_prop(prop) do
-    case String.split(prop, ":", parts: 2) do
-      [keyprops, val] ->
-        case String.split(keyprops, ";") do
-          ["DURATION"] ->
-            {:duration, {Timex.Duration.parse!(val), []}}
+    case split_content_line(prop) do
+      ["", _prop_val] ->
+        raise DecodeError, message: "property key missing or blank line"
 
-          [key] ->
-            {decode_key(key), {decode_value(val, []), []}}
+      [prop_key, ""] ->
+        raise DecodeError, message: "property has no value: #{inspect(prop_key)}"
 
-          [key | props] ->
-            props =
-              props
-              |> Enum.map(fn prop ->
-                [k, v] =
-                  case String.split(prop, "=") do
-                    [k1, v1] ->
-                      [k1, v1]
-
-                    [k1 | tl] ->
-                      # This case handles malformed X-APPLE-STRUCTURED-LOCATION
-                      # properties that fail to quote-escape `=` characters.
-                      [k1, Enum.join(tl, "=")]
-                  end
-
-                {decode_key(k), v}
-              end)
-
-            {decode_key(key), {decode_value(val, props), props}}
+      [prop_key, prop_val] ->
+        case prop_key do
+          "DURATION" -> {:duration, {decode_duration(prop_val), []}}
+          prop_key -> {decode_key(prop_key), {decode_value(prop_val, []), []}}
         end
 
-      prop ->
-        raise DecodeError, message: "property has no value: #{inspect(prop)}"
+      [prop_key | params_and_prop_val] ->
+        {raw_params, [prop_val]} = Enum.split(params_and_prop_val, -1)
+
+        params =
+          raw_params
+          |> Enum.map(fn raw_param ->
+            [k, v] = String.split(raw_param, "=", parts: 2)
+
+            {decode_key(k), v}
+          end)
+
+        {decode_key(prop_key), {decode_value(prop_val, params), params}}
     end
   end
+
+  defp split_content_line(line),
+    do: split_content_line(line, "", [], false)
+
+  # Following parses on a byte-by-byte basis.  This works because multi-byte
+  # UTF-8 won't contain these characters (ASCII starts with a 0 bit while all
+  # other UTF-8 bytes start with a 1 bit)
+  defp split_content_line("", char_acc, list_acc, _in_quotes),
+    do: ["" | [char_acc | list_acc]] |> Enum.reverse()
+
+  defp split_content_line(<<"\"", rest::binary>>, char_acc, list_acc, in_quotes),
+    do: split_content_line(rest, char_acc, list_acc, not in_quotes)
+
+  defp split_content_line(<<":", rest::binary>>, char_acc, list_acc, false = _in_quotes),
+    do: [rest | [char_acc | list_acc]] |> Enum.reverse()
+
+  defp split_content_line(<<";", rest::binary>>, char_acc, list_acc, false = in_quotes),
+    do: split_content_line(rest, "", [char_acc | list_acc], in_quotes)
+
+  defp split_content_line(<<char, rest::binary>>, char_acc, list_acc, in_quotes),
+    do: split_content_line(rest, char_acc <> <<char>>, list_acc, in_quotes)
 
   defp decode_value(val, props) do
     time_zone = Keyword.get(props, :tzid)

--- a/lib/calex/encoder.ex
+++ b/lib/calex/encoder.ex
@@ -64,7 +64,7 @@ defmodule Calex.Encoder do
   defp encode_value({k, {v, [{_k, _v} | _] = props}}) do
     encoded_props =
       props
-      |> Enum.map_join(";", fn {pk, pv} -> "#{encode_key(pk)}=#{encode_value(pv)}" end)
+      |> Enum.map_join(";", fn {pk, pv} -> "#{encode_key(pk)}=#{encode_param_value(pv)}" end)
 
     "#{encode_key(k)};#{encoded_props}:#{encode_value(v)}"
   end
@@ -74,6 +74,36 @@ defmodule Calex.Encoder do
 
   defp encode_value(atom) when is_atom(atom), do: atom |> to_string() |> String.upcase()
   defp encode_value(other), do: other
+
+  defp encode_param_value(atom) when is_atom(atom),
+    do: atom |> to_string() |> String.upcase() |> escape_param_value()
+
+  defp encode_param_value(string) when is_binary(string),
+    do: string |> escape_param_value()
+
+  defp encode_param_value(other),
+    do: other |> to_string() |> escape_param_value()
+
+  # param-value needs to be wrapped in double quotes if it contains
+  # ";", ":", or "," and must never contain a double quote or any
+  # control characters
+  # ref: https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
+  defp escape_param_value(value) do
+    # Not allowed to have a DQUOTE character in a value, but also
+    # no way to properly escape, so replace it with single quote.
+    # Then filter out all the CONTROL characters that are not allowed.
+    cleaned_value =
+      value
+      |> String.replace(~s("), ~s('))
+      |> String.replace(~r/[\x00-\x08\x0A-\x1F\x7F]/, "")
+
+    cleaned_value
+    |> String.contains?(~w(; : ,))
+    |> case do
+      true -> ~s("#{cleaned_value}")
+      false -> cleaned_value
+    end
+  end
 
   defp encode_key(k) do
     k |> to_string() |> String.replace("_", "-") |> String.upcase()

--- a/lib/calex/encoder.ex
+++ b/lib/calex/encoder.ex
@@ -72,8 +72,24 @@ defmodule Calex.Encoder do
   # encode value with empty props
   defp encode_value({k, {v, _}}), do: "#{encode_key(k)}:#{encode_value(v)}"
 
-  defp encode_value(atom) when is_atom(atom), do: atom |> to_string() |> String.upcase()
-  defp encode_value(other), do: other
+  defp encode_value(atom) when is_atom(atom),
+    do: atom |> to_string() |> String.upcase() |> escape_property_value()
+
+  defp encode_value(text) when is_binary(text),
+    do: text |> escape_property_value()
+
+  defp encode_value(other), do: other |> to_string() |> escape_property_value()
+
+  defp escape_property_value(value) do
+    value
+    |> String.replace(~r/(\\|;|,|\r\n|\n)/, fn
+      "\\" -> "\\\\"
+      ";" -> "\\;"
+      "," -> "\\,"
+      "\r\n" -> "\\n"
+      "\n" -> "\\n"
+    end)
+  end
 
   defp encode_param_value(atom) when is_atom(atom),
     do: atom |> to_string() |> String.upcase() |> escape_param_value()
@@ -116,7 +132,6 @@ defmodule Calex.Encoder do
     if String.length(bin) <= 75 do
       bin
     else
-      bin = String.replace(bin, ~r/[\r|\n]/, "\\n")
       {str_left, str_right} = String.split_at(bin, 75)
       str_left <> "\r\n " <> encode_line(str_right)
     end

--- a/test/calex/decoding_test.exs
+++ b/test/calex/decoding_test.exs
@@ -146,7 +146,7 @@ defmodule Calex.DecodingTest do
                 {"geo:42.145927,-100.585260",
                  [
                    value: "URI",
-                   x_address: "\"500 Nicollet St, Minneapolis, MN, United Stat\"",
+                   x_address: "500 Nicollet St, Minneapolis, MN, United Stat",
                    x_apple_mapkit_handle:
                      "CAEStwIIrk0QnsWIkObE3qLyARoS CVSPNLitEkpAEUGK8OV0pVrAIpoBCgZDYW5hZGESAkNBGgxTYXNrYXRjaGV3YW4iAlNLKg9EaXZpc2lvbiBOby4gMTEyCVNhc2thdG9vbjoHUzdOIDNQOUIMRm9yZXN0IEdyb3ZlUgpXZWJzdGVyIFN0WgM1MDJiDjUwMiBXZWJzdGVyIFN0igEWVW5pdmVyc2l0eSBIZWlnaHRzIFNEQYoBDEZvcmVzdCBHcm92ZSodRm9yZXN0IEdyb3ZlIENvbW11bml0eSBDaHVyY2gyDjUwMiBXZWJzdGVyIFN0MhRTYXNrYXRvb24gU0sgUzdOIDNQOTIGQ2FuYWRhOC9aJwolCJ7FiJDmxN6i8gESEglUjzS4rRJKQBFBivDldKVawBiuTZADAQ==",
                    x_apple_radius: "123.4774275404302",
@@ -180,7 +180,37 @@ defmodule Calex.DecodingTest do
         e in [Calex.DecodeError] -> e
       end
 
-    assert exception.message == "property has no value: [\"Myrtle Beach SC 29579\"]"
+    assert exception.message == "property has no value: \"Myrtle Beach SC 29579\""
+  end
+
+  test "fails on line with no property key" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      :text
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert_raise(Calex.DecodeError, "property key missing or blank line", fn ->
+      Calex.decode!(data)
+    end)
+  end
+
+  test "fails on blank line" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert_raise(Calex.DecodeError, "property key missing or blank line", fn ->
+      Calex.decode!(data)
+    end)
   end
 
   test "decodes negative GMT offset dates" do
@@ -310,6 +340,38 @@ defmodule Calex.DecodingTest do
     assert_raise Calex.InvalidTimeZoneError, fn ->
       Calex.decode!(data)
     end
+  end
+
+  test "escaped semicolon and colon in param values" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      ORGANIZER;CN=Dwayne 'The Rock' Johnson;SENT-BY="mailto:person@example.com";
+       X-COMMA="1,2,3";X-SEMICOLON="1;2;3":mailto:organizer@example.com
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert Calex.decode!(data) == [
+             vcalendar: [
+               [
+                 vevent: [
+                   [
+                     organizer: {
+                       "mailto:organizer@example.com",
+                       [
+                         cn: "Dwayne 'The Rock' Johnson",
+                         sent_by: "mailto:person@example.com",
+                         x_comma: "1,2,3",
+                         x_semicolon: "1;2;3"
+                       ]
+                     }
+                   ]
+                 ]
+               ]
+             ]
+           ]
   end
 
   defp crlf(string) do

--- a/test/calex/decoding_test.exs
+++ b/test/calex/decoding_test.exs
@@ -300,6 +300,52 @@ defmodule Calex.DecodingTest do
            ]
   end
 
+  test "bad DURATION property value is just returned as-is" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      DURATION:LONGTIME
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert Calex.decode!(data) == [
+             vcalendar: [
+               [
+                 vevent: [
+                   [
+                     duration: {"LONGTIME", []}
+                   ]
+                 ]
+               ]
+             ]
+           ]
+  end
+
+  test "bad DURATION value is just returned as-is" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      X-APPLE-TRAVEL-DURATION;VALUE=DURATION:LONGTIME
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert Calex.decode!(data) == [
+             vcalendar: [
+               [
+                 vevent: [
+                   [
+                     x_apple_travel_duration: {"LONGTIME", [value: "DURATION"]}
+                   ]
+                 ]
+               ]
+             ]
+           ]
+  end
+
   test "truncates very long property names" do
     long_name = 0..256 |> Enum.map_join(fn _ -> "X" end)
     truncated_long_name = 0..254 |> Enum.map_join(fn _ -> "x" end) |> String.to_atom()
@@ -394,6 +440,35 @@ defmodule Calex.DecodingTest do
                        "text escaping \\ ; , \n \n \\n end",
                        []
                      }
+                   ]
+                 ]
+               ]
+             ]
+           ]
+  end
+
+  test "accumulate blocks of the same key" do
+    data =
+      crlf("""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      SUBJECT:event 1
+      END:VEVENT
+      BEGIN:VEVENT
+      SUBJECT:event 2
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert Calex.decode!(data) == [
+             vcalendar: [
+               [
+                 vevent: [
+                   [
+                     subject: {"event 1", []}
+                   ],
+                   [
+                     subject: {"event 2", []}
                    ]
                  ]
                ]

--- a/test/calex/decoding_test.exs
+++ b/test/calex/decoding_test.exs
@@ -132,7 +132,7 @@ defmodule Calex.DecodingTest do
        cm92ZSodRm9yZXN0IEdyb3ZlIENvbW11bml0eSBDaHVyY2gyDjUwMiBXZWJzdGVyIFN0MhRTYXN
        rYXRvb24gU0sgUzdOIDNQOTIGQ2FuYWRhOC9aJwolCJ7FiJDmxN6i8gESEglUjzS4rRJKQBFBiv
        DldKVawBiuTZADAQ==;X-APPLE-RADIUS=123.4774275404302;X-APPLE-REFERENCEFRAME=
-       1;X-TITLE=The Wedge:geo:42.145927,-100.585260
+       1;X-TITLE=The Wedge:geo:42.145927\\,-100.585260
       END:VEVENT
       END:VCALENDAR
       """)
@@ -366,6 +366,33 @@ defmodule Calex.DecodingTest do
                          x_comma: "1,2,3",
                          x_semicolon: "1;2;3"
                        ]
+                     }
+                   ]
+                 ]
+               ]
+             ]
+           ]
+  end
+
+  test "escaped characters in property value" do
+    # note the ~S used here to disable escaping
+    data =
+      crlf(~S"""
+      BEGIN:VCALENDAR
+      BEGIN:VEVENT
+      DESCRIPTION:text escaping \\ \; \, \N \n \\n end
+      END:VEVENT
+      END:VCALENDAR
+      """)
+
+    assert Calex.decode!(data) == [
+             vcalendar: [
+               [
+                 vevent: [
+                   [
+                     description: {
+                       "text escaping \\ ; , \n \n \\n end",
+                       []
                      }
                    ]
                  ]

--- a/test/calex/encoding_test.exs
+++ b/test/calex/encoding_test.exs
@@ -184,6 +184,40 @@ defmodule Calex.EncodingTest do
              """)
   end
 
+  test "parameter values are properly escaped" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              organizer: {
+                "mailto:organizer@example.com",
+                [
+                  cn: ~s(Dwayne "The Rock" \n\nJohnson),
+                  sent_by: "mailto:person@example.com",
+                  x_comma: "1,2,3",
+                  x_semicolon: "1;2;3",
+                  x_type: :important
+                ]
+              }
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             ORGANIZER;CN=Dwayne 'The Rock' Johnson;SENT-BY="mailto:person@example.com";
+              X-COMMA="1,2,3";X-SEMICOLON="1;2;3";X-TYPE=IMPORTANT:mailto:organizer@examp
+              le.com
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
   defp crlf(string) do
     string
     |> String.split("\n")

--- a/test/calex/encoding_test.exs
+++ b/test/calex/encoding_test.exs
@@ -218,6 +218,33 @@ defmodule Calex.EncodingTest do
              """)
   end
 
+  test "escaped characters in property value" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              description: {
+                "text escaping \\ ; , \n \r\n \\n \" end",
+                []
+              }
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    # note the ~S used here to disable escaping
+    assert Calex.encode!(data) ==
+             crlf(~S"""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             DESCRIPTION:text escaping \\ \; \, \n \n \\n " end
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
   defp crlf(string) do
     string
     |> String.split("\n")

--- a/test/calex/encoding_test.exs
+++ b/test/calex/encoding_test.exs
@@ -184,6 +184,52 @@ defmodule Calex.EncodingTest do
              """)
   end
 
+  test "encodes atom property value" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              class: {:public, []}
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             CLASS:PUBLIC
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
+  test "unhandled types are just used as-is" do
+    data = [
+      vcalendar: [
+        [
+          vevent: [
+            [
+              x_unknown: {1, [x_foo: 2]}
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assert Calex.encode!(data) ==
+             crlf("""
+             BEGIN:VCALENDAR
+             BEGIN:VEVENT
+             X-UNKNOWN;X-FOO=2:1
+             END:VEVENT
+             END:VCALENDAR
+             """)
+  end
+
   test "parameter values are properly escaped" do
     data = [
       vcalendar: [


### PR DESCRIPTION
RFC 5545 allows for and requires certain escaping on icalendar lines.

Prior to this PR, a line such as `ORGANIZER;SENT-BY="mailto:test@example.com":mailto:organizer@example.com` would fail to parse properly as it would split the line on the first `:` found, but that's within double-quotes as a parameter value and isn't a separator.  A similar issue happens with `;` in a parameter value.  Likewise, when encoding into an icalendar file, if a parameter value contains certain characters then it needs to be wrapped in double quotes.

Property values (the part after the `:` separator) also has a series of escaping rules involving back-slashes.  Most commonly is `\n` for line feeds, but also `\\`, `\,`, `\;`, and even `\N`.  This PR helps with those in both encoding and decoding.

Additionally, I noticed a few lines didn't have code coverage, so I added a few more tests for those.